### PR TITLE
Remove direct references to #websocket_req{} and hide it fully inside an...

### DIFF
--- a/include/websocket_client.hrl
+++ b/include/websocket_client.hrl
@@ -6,20 +6,4 @@
   {text | binary | close | ping | pong, binary()}
   | {close, 1000..4999, binary()}.
 
--record(websocket_req, {
-          protocol :: protocol(),
-          host :: string(),
-          port :: inet:port_number(),
-          path ::  string(),
-          keepalive :: integer(),
-          socket :: inet:socket() | ssl:sslsocket(),
-          transport :: module(),
-          handler :: module(),
-          key :: binary(),
-          remaining :: undefined | integer(),
-          opcode :: opcode()
-         }).
-
--opaque websocket_req() :: #websocket_req{}.
-
--export_type([websocket_req/0, protocol/0, opcode/0, frame/0]).
+-export_type([protocol/0, opcode/0, frame/0]).

--- a/src/websocket_client_handler.erl
+++ b/src/websocket_client_handler.erl
@@ -6,19 +6,19 @@
 -type keepalive() :: integer().
 
 %% @doc spe
--callback init(list(), websocket_req()) ->
+-callback init(list(), websocket_req:req()) ->
     {ok, state()}
         | {ok, state(), keepalive()}.
 
--callback websocket_handle({text | binary | ping | pong, binary()}, websocket_req(), state()) ->
+-callback websocket_handle({text | binary | ping | pong, binary()}, websocket_req:req(), state()) ->
     {ok, state()}
         | {reply, websocket_client:frame(), state()}
         | {close, binary(), state()}.
 
--callback websocket_info(any(), websocket_req(), state()) ->
+-callback websocket_info(any(), websocket_req:req(), state()) ->
     {ok, state()}
         | {reply, websocket_client:frame(), state()}
         | {close, binary(),  state()}.
 
--callback websocket_terminate({close, integer(), binary()},  websocket_req(), state()) ->
+-callback websocket_terminate({close, integer(), binary()},  websocket_req:req(), state()) ->
     ok.

--- a/src/websocket_req.erl
+++ b/src/websocket_req.erl
@@ -11,20 +11,20 @@
           host      :: string(),
           port      :: inet:port_number(),
           path      :: string(),
-          keepalive :: integer(),
+          keepalive :: inifinity | integer(),
           socket    :: inet:socket() | ssl:sslsocket(),
           transport :: module(),
           handler   :: module(),
           key       :: binary(),
           remaining :: undefined | integer(),
-          opcode    :: opcode()
+          opcode    :: undefined | opcode()
          }).
 
 -opaque req() :: #websocket_req{}.
 -export_type([req/0]).
 
 
--export([new/1,
+-export([new/11,
          protocol/2,   protocol/1,
          host/2,       host/1,
          port/2,       port/1,
@@ -38,22 +38,47 @@
          opcode/2,     opcode/1
         ]).
 
--spec new([tuple()]) -> req().
-new(Args) ->
-    new(Args, #websocket_req{}).
+-export([
+    opcode_to_name/1,
+    name_to_opcode/1
+    ]).
 
-new([], Req) -> Req;
-new([{protocol , Val} | Props], Req) -> new(Props, Req#websocket_req{protocol   = Val}); 
-new([{host     , Val} | Props], Req) -> new(Props, Req#websocket_req{host       = Val}); 
-new([{port     , Val} | Props], Req) -> new(Props, Req#websocket_req{port       = Val}); 
-new([{path     , Val} | Props], Req) -> new(Props, Req#websocket_req{path       = Val}); 
-new([{keepalive, Val} | Props], Req) -> new(Props, Req#websocket_req{keepalive  = Val}); 
-new([{socket   , Val} | Props], Req) -> new(Props, Req#websocket_req{socket     = Val}); 
-new([{transport, Val} | Props], Req) -> new(Props, Req#websocket_req{transport  = Val}); 
-new([{handler  , Val} | Props], Req) -> new(Props, Req#websocket_req{handler    = Val}); 
-new([{key      , Val} | Props], Req) -> new(Props, Req#websocket_req{key        = Val}); 
-new([{remaining, Val} | Props], Req) -> new(Props, Req#websocket_req{remaining  = Val}); 
-new([{opcode   , Val} | Props], Req) -> new(Props, Req#websocket_req{opcode     = Val}).
+-spec new(protocol(), string(), inet:port_number(), string(), integer(), inet:socket() | ssl:sslsocket(), module(), module(), binary(), undefined | integer(), opcode()) -> req().
+new(Protocol, Host, Port,
+    Path, Keepalive, Socket,
+    Transport, Handler, Key, Remaining, Opcode) ->
+    #websocket_req{
+        protocol  = Protocol,
+        host      = Host,
+        port      = Port,
+        path      = Path,
+        keepalive = Keepalive,
+        socket    = Socket,
+        transport = Transport,
+        handler   = Handler,
+        key       = Key,
+        remaining = Remaining,
+        opcode    = Opcode   
+    }.
+
+
+%% @doc Mapping from opcode to opcode name
+-spec opcode_to_name(opcode()) ->
+    atom().
+opcode_to_name(1) -> text;
+opcode_to_name(2) -> binary;
+opcode_to_name(8) -> close;
+opcode_to_name(9) -> ping;
+opcode_to_name(10) -> pong.
+
+%% @doc Mapping from opcode to opcode name
+-spec name_to_opcode(atom()) ->
+    opcode().
+name_to_opcode(text) -> 1;
+name_to_opcode(binary) -> 2;
+name_to_opcode(close) -> 8;
+name_to_opcode(ping) -> 9;
+name_to_opcode(pong) -> 10.
 
 
 -spec protocol(req()) -> protocol().

--- a/src/websocket_req.erl
+++ b/src/websocket_req.erl
@@ -6,56 +6,140 @@
 
 -include("websocket_client.hrl").
 
--export([protocol/1,
-         host/1,
-         port/1,
-         path/1,
-         keepalive/1,
-         socket/1,
-         transport/1,
-         handler/1,
-         key/1,
-         remaining/1,
-         opcode/1]).
+-record(websocket_req, {
+          protocol  :: protocol(),
+          host      :: string(),
+          port      :: inet:port_number(),
+          path      :: string(),
+          keepalive :: integer(),
+          socket    :: inet:socket() | ssl:sslsocket(),
+          transport :: module(),
+          handler   :: module(),
+          key       :: binary(),
+          remaining :: undefined | integer(),
+          opcode    :: opcode()
+         }).
 
--spec protocol(websocket_req()) -> protocol().
+-opaque req() :: #websocket_req{}.
+-export_type([req/0]).
+
+
+-export([new/1,
+         protocol/2,   protocol/1,
+         host/2,       host/1,
+         port/2,       port/1,
+         path/2,       path/1,
+         keepalive/2,  keepalive/1,
+         socket/2,     socket/1,
+         transport/2,  transport/1,
+         handler/2,    handler/1,
+         key/2,        key/1,
+         remaining/2,  remaining/1,
+         opcode/2,     opcode/1
+        ]).
+
+-spec new([tuple()]) -> req().
+new(Args) ->
+    new(Args, #websocket_req{}).
+
+new([], Req) -> Req;
+new([{protocol , Val} | Props], Req) -> new(Props, Req#websocket_req{protocol   = Val}); 
+new([{host     , Val} | Props], Req) -> new(Props, Req#websocket_req{host       = Val}); 
+new([{port     , Val} | Props], Req) -> new(Props, Req#websocket_req{port       = Val}); 
+new([{path     , Val} | Props], Req) -> new(Props, Req#websocket_req{path       = Val}); 
+new([{keepalive, Val} | Props], Req) -> new(Props, Req#websocket_req{keepalive  = Val}); 
+new([{socket   , Val} | Props], Req) -> new(Props, Req#websocket_req{socket     = Val}); 
+new([{transport, Val} | Props], Req) -> new(Props, Req#websocket_req{transport  = Val}); 
+new([{handler  , Val} | Props], Req) -> new(Props, Req#websocket_req{handler    = Val}); 
+new([{key      , Val} | Props], Req) -> new(Props, Req#websocket_req{key        = Val}); 
+new([{remaining, Val} | Props], Req) -> new(Props, Req#websocket_req{remaining  = Val}); 
+new([{opcode   , Val} | Props], Req) -> new(Props, Req#websocket_req{opcode     = Val}).
+
+
+-spec protocol(req()) -> protocol().
 protocol(#websocket_req{protocol = P}) -> P.
 
+-spec protocol(protocol(), req()) -> req().
+protocol(P, Req) ->
+	Req#websocket_req{protocol = P}.
 
--spec host(websocket_req()) -> string().
+
+-spec host(req()) -> string().
 host(#websocket_req{host = H}) -> H.
 
+-spec host(string(), req()) -> req().
+host(H, Req) ->
+	Req#websocket_req{host = H}.
 
--spec port(websocket_req()) -> inet:port_number().
+
+-spec port(req()) -> inet:port_number().
 port(#websocket_req{port = P}) -> P.
 
+-spec port(inet:port_number(), req()) -> req().
+port(P, Req) ->
+	Req#websocket_req{port = P}.
 
--spec path(websocket_req()) ->  string().
+
+-spec path(req()) -> string().
 path(#websocket_req{path = P}) -> P.
 
+-spec path(string(), req()) -> req().
+path(P, Req) ->
+	Req#websocket_req{path = P}.
 
--spec keepalive(websocket_req()) -> integer().
+
+-spec keepalive(req()) -> integer().
 keepalive(#websocket_req{keepalive = K}) -> K.
 
+-spec keepalive(integer(), req()) -> req().
+keepalive(K, Req) ->
+	Req#websocket_req{keepalive = K}.
 
--spec socket(websocket_req()) -> inet:socket() | ssl:sslsocket().
+
+-spec socket(req()) -> inet:socket() | ssl:sslsocket().
 socket(#websocket_req{socket = S}) -> S.
 
+-spec socket(inet:socket() | ssl:sslsocket(), req()) -> req().
+socket(S, Req) ->
+	Req#websocket_req{socket = S}.
 
--spec transport(websocket_req()) -> module().
+
+-spec transport(req()) -> module().
 transport(#websocket_req{transport = T}) -> T.
 
+-spec transport(module(), req()) -> req().
+transport(T, Req) ->
+	Req#websocket_req{transport = T}.
 
--spec handler(websocket_req()) -> module().
+
+-spec handler(req()) -> module().
 handler(#websocket_req{handler = H}) -> H.
 
+-spec handler(module(), req()) -> req().
+handler(H, Req) ->
+	Req#websocket_req{handler = H}.
 
--spec key(websocket_req()) -> binary().
+
+-spec key(req()) -> binary().
 key(#websocket_req{key = K}) -> K.
 
+-spec key(binary(), req()) -> req().
+key(K, Req) ->
+	Req#websocket_req{key = K}.
 
--spec remaining(websocket_req()) -> undefined | integer().
+
+-spec remaining(req()) -> undefined | integer().
 remaining(#websocket_req{remaining = R}) -> R.
 
--spec opcode(websocket_req()) -> opcode().
+-spec remaining(undefined | integer(), req()) -> req().
+remaining(R, Req) ->
+	Req#websocket_req{remaining = R}.
+
+
+-spec opcode(req()) -> opcode().
 opcode(#websocket_req{opcode = O}) -> O.
+
+-spec opcode(opcode(), req()) -> req().
+opcode(O, Req) ->
+	Req#websocket_req{opcode = O}.
+


### PR DESCRIPTION
... accessor module

I'm not 100% convinced about the websocket_req:new/1 function. It just seems... wrong.

Also this API means that updating more than 1 field is kinda clunky. Does the dynarec stuff you mentioned the other day provide a better interface?

I guess an improvement would be to add a function for updating the record from a proplist (as per websocket_req:new/1) for multiple fields, then use this from websocket_req:new/1 instead? Thoughts? Comments?
